### PR TITLE
Create team.py

### DIFF
--- a/team.py
+++ b/team.py
@@ -1,0 +1,48 @@
+import requests
+
+## Enter the ENTERPRISE_SLUG, TEAM_NAME_FILTER, and AUTH_TOKEN values below
+## Run the script using the command: python get_users.py
+
+# Global constants
+ENTERPRISE_SLUG = '' # your_enterprise_slug_here
+TEAM_NAME_FILTER = '' # your_team_name_here
+AUTH_TOKEN = '' # your_auth_token_here Use token (Classic) with the following scopes: "manage_billing:copilot" or "read:enterprise"
+
+def get_copilot_billing_seats():
+    # Construct the API URL using the enterprise slug
+    api_url = f"https://api.github.com/enterprises/{ENTERPRISE_SLUG}/copilot/billing/seats"
+
+    # Headers dictionary to include the Authorization header
+    headers = {
+        "Authorization": f"Bearer {AUTH_TOKEN}"
+    }
+
+    # Make the API request with the Authorization header
+    response = requests.get(api_url, headers=headers)
+
+    # Check if the request was successful
+    if response.status_code == 200:
+        # Parse the JSON response
+        data = response.json()
+    else:
+        # Handle errors (e.g., network issues, invalid slug, etc.)
+        return f"Error: Received response code {response.status_code}"
+
+    # Filter data based on TEAM_NAME_FILTER and extract "login" from "assignee"
+    users_info = [
+        {
+            'login': item.get('assignee', {}).get('login'), 
+            'last_activity_at': item.get('last_activity_at')
+        }
+        for item in data['seats'] 
+        if item.get('assigning_team', {}).get('name') == TEAM_NAME_FILTER 
+        and item.get('assignee') 
+        and item.get('assignee').get('login')
+    ]
+    return users_info
+
+# Example usage
+if __name__ == "__main__":
+    seats_info = get_copilot_billing_seats()
+    print(f"Seats Info: {seats_info}")
+    print(f"Number of users in '{TEAM_NAME_FILTER}': {len(seats_info)}")


### PR DESCRIPTION
This pull request primarily introduces a new function `get_copilot_billing_seats()` in the `team.py` file. This function is designed to fetch and filter GitHub Copilot billing seat information for a specific team within an enterprise.

Key changes include:

* Added `requests` library for making HTTP requests.
* Defined global constants `ENTERPRISE_SLUG`, `TEAM_NAME_FILTER`, and `AUTH_TOKEN` for customization.
* Implemented the `get_copilot_billing_seats()` function which constructs an API URL using the enterprise slug, makes an API request with the Authorization header, checks for successful response, parses the JSON response, filters data based on `TEAM_NAME_FILTER`, and extracts user login information and their last activity timestamp.
* Provided an example usage of the function in the `__main__` section of the script.

This function will allow users to fetch and filter GitHub Copilot billing seat information for a specific team within an enterprise by simply providing the appropriate global constant values and running the script.